### PR TITLE
Remove Warning messages

### DIFF
--- a/sqlalchemy_schemadisplay.py
+++ b/sqlalchemy_schemadisplay.py
@@ -8,7 +8,7 @@ import types
 __all__ = ['create_uml_graph', 'create_schema_graph', 'show_uml_graph', 'show_schema_graph']
 
 def _mk_label(mapper, show_operations, show_attributes, show_datatypes, show_inherited, bordersize):
-    html = '<<TABLE CELLSPACING="0" CELLPADDING="1" BORDER="0" CELLBORDER="%d" BALIGN="LEFT"><TR><TD><FONT POINT-SIZE="10">%s</FONT></TD></TR>' % (bordersize, mapper.class_.__name__)
+    html = '<<TABLE CELLSPACING="0" CELLPADDING="1" BORDER="0" CELLBORDER="%d" ALIGN="LEFT"><TR><TD><FONT POINT-SIZE="10">%s</FONT></TD></TR>' % (bordersize, mapper.class_.__name__)
     def format_col(col):
         colstr = '+%s' % (col.name)
         if show_datatypes:


### PR DESCRIPTION
The BALIGN table attribute was causing some warning messages like this

    Warning: Illegal attribute BALIGN in <TABLE> - ignored  

This commit uses a valid table attribute to avoid warning messages in the standard output during the creation of schema files.