### PR TITLE
Update sqlalchemy_schemadisplay.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,8 @@ Changelog
 1.4 - Unreleased
 ----------------
 
-
+- Set dir kwarg in Edge instantiation to 'both' in order to show arrow heads and arrow tails 
+  [bkrn - Aaron Di Silvestro]
 
 1.3 - 2016-01-27
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Changelog
 1.4 - Unreleased
 ----------------
 
-- Set dir kwarg in Edge instantiation to 'both' in order to show arrow heads and arrow tails 
+- Set dir kwarg in Edge instantiation to 'both' in order to show arrow heads and arrow tails.
   [bkrn - Aaron Di Silvestro]
 
 1.3 - 2016-01-27

--- a/sqlalchemy_schemadisplay.py
+++ b/sqlalchemy_schemadisplay.py
@@ -163,6 +163,7 @@ def create_schema_graph(tables=None, metadata=None, show_indexes=True, show_data
             if is_inheritance:
                 edge = edge[::-1]
             graph_edge = pydot.Edge(
+                dir='both',
                 headlabel="+ %s"%fk.column.name, taillabel='+ %s'%fk.parent.name,
                 arrowhead=is_inheritance and 'none' or 'odot' ,
                 arrowtail=(fk.parent.primary_key or fk.parent.unique) and 'empty' or 'crow' ,


### PR DESCRIPTION
added dir='both' to Edge instantiation kwargs since it seems to be required to draw both the arrowhead and arrowtail.
