### PR TITLE
Change column name appearance and allow user to restrict tables from schema

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,10 @@ Changelog
 
 - Set dir kwarg in Edge instantiation to 'both' in order to show arrow heads and arrow tails.
   [bkrn - Aaron Di Silvestro]
+  
+- Add 'show_column_keys' kwarg to 'create_schema_graph' to allow a PK/FK suffix to be added to columns that are primary keys/foreign keys respectively [cchrysostomou - Constantine Chrysostomou]
+
+- Add 'restrict_tables' kwarg to 'create_schema_graph' to restrict the desired tables we want to generate via graphviz and show relationships for [cchrysostomou - Constantine Chrysostomou]
 
 1.3 - 2016-01-27
 ----------------

--- a/sqlalchemy_schemadisplay.py
+++ b/sqlalchemy_schemadisplay.py
@@ -127,7 +127,7 @@ def _render_table_html(table, metadata, show_indexes, show_datatypes, show_colum
             return str(col.type)
     def format_col_str(col):
          # add in (PK) OR (FK) suffixes to column names that are considered to be primary key or foreign key
-         suffix = '(FK)' if col.name in fk_col_names else '(PK)' if col.name in pk_key_names else ''
+         suffix = '(FK)' if col.name in fk_col_names else '(PK)' if col.name in pk_col_names else ''
          if show_datatypes:
              return "- %s : %s" % (col.name + suffix, format_col_type(col))
          else:

--- a/sqlalchemy_schemadisplay.py
+++ b/sqlalchemy_schemadisplay.py
@@ -104,7 +104,7 @@ def create_uml_graph(mappers, show_operations=True, show_attributes=True, show_i
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy import Table, text  # , ForeignKeyConstraint
 
-def _render_table_html(table, metadata, show_indexes, show_datatypes):    
+def _render_table_html(table, metadata, show_indexes, show_datatypes, show_column_keys):    
     # add in (PK) OR (FK) suffixes to column names that are considered to be primary key or foreign key
     # use_column_key_attr = hasattr(ForeignKeyConstraint, 'column_keys')  # sqlalchemy > 1.0 uses column_keys to return list of strings for foreign keys, previously was columns
     if show_column_keys:

--- a/sqlalchemy_schemadisplay.py
+++ b/sqlalchemy_schemadisplay.py
@@ -102,24 +102,24 @@ def create_uml_graph(mappers, show_operations=True, show_attributes=True, show_i
     return graph
 
 from sqlalchemy.dialects.postgresql.base import PGDialect
-from sqlalchemy import Table, text  # , ForeignKeyConstraint
+from sqlalchemy import Table, text, ForeignKeyConstraint
 
-def _render_table_html(table, metadata, show_indexes, show_datatypes, show_column_keys):    
+def _render_table_html(table, metadata, show_indexes, show_datatypes, show_column_keys):
     # add in (PK) OR (FK) suffixes to column names that are considered to be primary key or foreign key
-    # use_column_key_attr = hasattr(ForeignKeyConstraint, 'column_keys')  # sqlalchemy > 1.0 uses column_keys to return list of strings for foreign keys, previously was columns
+    use_column_key_attr = hasattr(ForeignKeyConstraint, 'column_keys')  # sqlalchemy > 1.0 uses column_keys to return list of strings for foreign keys, previously was columns
     if show_column_keys:
-        # if (use_column_key_attr):
-        #     # sqlalchemy > 1.0
-        #     fk_col_names = set([h for f in table.foreign_keys for h in f.constraint.column_keys])
-        # else:
-        #     # sqlalchemy pre 1.0?
-        #     fk_col_names = set([h for f in table.foreign_keys for h in f.constraint.columns])
-        fk_col_names = set([h for f in table.foreign_key_constraints for h in f.columns.keys()])
+        if (use_column_key_attr):
+            # sqlalchemy > 1.0
+            fk_col_names = set([h for f in table.foreign_key_constraints for h in f.columns.keys()])
+        else:
+            # sqlalchemy pre 1.0?
+            fk_col_names = set([h.name for f in table.foreign_keys for h in f.constraint.columns])
+        # fk_col_names = set([h for f in table.foreign_key_constraints for h in f.columns.keys()])
         pk_col_names = set([f for f in table.primary_key.columns.keys()])
     else:
         fk_col_names = set()
         pk_col_names = set()
-    
+
     def format_col_type(col):
         try:
             return col.type.get_col_spec()
@@ -154,7 +154,7 @@ def create_schema_graph(tables=None, metadata=None, show_indexes=True, show_data
       show_column_keys (boolean, default=False): If true then add a PK/FK suffix to columns names that are primary and foreign keys
       restrict_tables (None or list of strings): Restrict the graph to only consider tables whose name are defined restrict_tables
     """
-    
+
     relation_kwargs = {
         'fontsize':"7.0"
     }
@@ -169,21 +169,21 @@ def create_schema_graph(tables=None, metadata=None, show_indexes=True, show_data
     else:
         raise ValueError("You need to specify at least tables or metadata")
 
-    graph = pydot.Dot(prog="dot",mode="ipsep",overlap="ipsep",sep="0.01",concentrate=str(concentrate), rankdir=rankdir)    
+    graph = pydot.Dot(prog="dot",mode="ipsep",overlap="ipsep",sep="0.01",concentrate=str(concentrate), rankdir=rankdir)
     if restrict_tables is None:
         restrict_tables = set([t.name.lower() for t in tables])
     else:
         restrict_tables = set([t.lower() for t in restrict_tables])
     tables = [t for t in tables if t.name in restrict_tables]
-    for table in tables:        
-        
+    for table in tables:
+
         graph.add_node(pydot.Node(str(table.name),
             shape="plaintext",
             label=_render_table_html(table, metadata, show_indexes, show_datatypes, show_column_keys),
             fontname=font, fontsize="7.0"
         ))
 
-    for table in tables:        
+    for table in tables:
         for fk in table.foreign_keys:
             if fk.column.table not in tables:
                 continue

--- a/sqlalchemy_schemadisplay.py
+++ b/sqlalchemy_schemadisplay.py
@@ -179,7 +179,7 @@ def create_schema_graph(tables=None, metadata=None, show_indexes=True, show_data
         
         graph.add_node(pydot.Node(str(table.name),
             shape="plaintext",
-            label=_render_table_html(table, metadata, show_indexes, show_datatypes),
+            label=_render_table_html(table, metadata, show_indexes, show_datatypes, show_column_keys),
             fontname=font, fontsize="7.0"
         ))
 

--- a/tests/test_schema_graph.py
+++ b/tests/test_schema_graph.py
@@ -44,6 +44,15 @@ def test_empty_table(metadata):
     assert result['1']['nodes'].keys() == ['foo']
     assert '- id : INTEGER' in result['1']['nodes']['foo']
 
+def test_empty_table_with_key_suffix(metadata):
+    Table(
+        'foo', metadata,
+        Column('id', types.Integer, primary_key=True))
+    result = plain_result(metadata=metadata, show_column_keys=True)
+    print(result)
+    assert result.keys() == ['1']
+    assert result['1']['nodes'].keys() == ['foo']
+    assert '- id(PK) : INTEGER' in result['1']['nodes']['foo']
 
 def test_foreign_key(metadata):
     foo = Table(
@@ -60,6 +69,20 @@ def test_foreign_key(metadata):
     assert 'edges' in result['1']
     assert ('bar', 'foo') in result['1']['edges']
 
+def test_foreign_key_with_key_suffix(metadata):
+    foo = Table(
+        'foo', metadata,
+        Column('id', types.Integer, primary_key=True))
+    Table(
+        'bar', metadata,
+        Column('foo_id', types.Integer, ForeignKey(foo.c.id)))
+    result = plain_result(metadata=metadata, show_column_keys=True)
+    assert result.keys() == ['1']
+    assert sorted(result['1']['nodes'].keys()) == ['bar', 'foo']
+    assert '- id(PK) : INTEGER' in result['1']['nodes']['foo']
+    assert '- foo_id(FK) : INTEGER' in result['1']['nodes']['bar']
+    assert 'edges' in result['1']
+    assert ('bar', 'foo') in result['1']['edges']
 
 def test_table_filtering(metadata):
     foo = Table(


### PR DESCRIPTION
1) This will add a (FK) suffix to column names that are foreign keys and (PK) suffix to column names that are primary keys. 
2) in addition a user can add new argument to `create_schema_graph` where they pass in a list of table names they want rendered. Useful if schema has many tables and only want to show a subset of relationships. 