### PR TITLE
Fixing error with python 3

### DIFF
--- a/sqlalchemy_schemadisplay.py
+++ b/sqlalchemy_schemadisplay.py
@@ -213,13 +213,19 @@ def create_schema_graph(tables=None, metadata=None, show_indexes=True, show_data
     return graph
 
 def show_uml_graph(*args, **kwargs):
-    from cStringIO import StringIO
+    try:
+        from cStringIO import StringIO
+    except ImportError:
+        from io import StringIO
     from PIL import Image
     iostream = StringIO(create_uml_graph(*args, **kwargs).create_png())
     Image.open(iostream).show(command=kwargs.get('command','gwenview'))
 
 def show_schema_graph(*args, **kwargs):
-    from cStringIO import StringIO
+    try:
+        from cStringIO import StringIO
+    except ImportError:
+        from io import StringIO
     from PIL import Image
     iostream = StringIO(create_schema_graph(*args, **kwargs).create_png())
     Image.open(iostream).show(command=kwargs.get('command','gwenview'))


### PR DESCRIPTION
cStringIO is not available in python 3.x. `StringIO` is available from `io` library.

Fixes #13