### PR TITLE
Update setup.py to use pydot which has py3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     zip_safe=True,
     install_requires=[
         'setuptools',
-        'pydot3',
+        'pydot',
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
pydot has Python 3 support, so it is possible to change back dependency to regular pydot package.