### PR TITLE
Add schema display options

### DIFF
--- a/sqlalchemy_schemadisplay.py
+++ b/sqlalchemy_schemadisplay.py
@@ -105,7 +105,11 @@ from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy import Table, text, ForeignKeyConstraint
 
 
-def _render_table_html(table, metadata, show_indexes, show_datatypes, show_column_keys, show_schema_name, format_schema_name, format_table_name):
+def _render_table_html(
+    table, metadata,
+    show_indexes, show_datatypes, show_column_keys, show_schema_name,
+    format_schema_name, format_table_name
+):
     # add in (PK) OR (FK) suffixes to column names that are considered to be primary key or foreign key
     use_column_key_attr = hasattr(ForeignKeyConstraint, 'column_keys')  # sqlalchemy > 1.0 uses column_keys to return list of strings for foreign keys, previously was columns
     if show_column_keys:
@@ -166,7 +170,9 @@ def _render_table_html(table, metadata, show_indexes, show_datatypes, show_colum
     html += ''.join('<TR><TD ALIGN="LEFT" PORT="%s">%s</TD></TR>' % (col.name, format_col_str(col)) for col in table.columns)
     if metadata.bind and isinstance(metadata.bind.dialect, PGDialect):
         # postgres engine doesn't reflect indexes
-        indexes = dict((name,defin) for name,defin in metadata.bind.execute(text("SELECT indexname, indexdef FROM pg_indexes WHERE tablename = '%s'" % table.name)))
+        indexes = dict((name,defin) for name,defin in metadata.bind.execute(
+            text("SELECT indexname, indexdef FROM pg_indexes WHERE tablename = '%s'" % table.name)
+        ))
         if indexes and show_indexes:
             html += '<TR><TD BORDER="1" CELLPADDING="0"></TD></TR>'
             for index, defin in indexes.items():
@@ -181,15 +187,24 @@ def create_schema_graph(tables=None, metadata=None, show_indexes=True, show_data
     show_schema_name=False, format_schema_name=None, format_table_name=None):
     """
     Args:
-      - metadata (sqlalchemy.MetaData, default=None): SqlAlchemy `MetaData` with reference to related tables.  If none is provided, uses metadata from first entry of `tables` argument.
-      - concentrate (bool, default=True): Specifies if multiedges should be merged into a single edge & partially parallel edges to share overlapping path.  Passed to `pydot.Dot` object.
-      - relation_options (dict, default: None): kwargs passed to pydot.Edge init.  Most attributes in pydot.EDGE_ATTRIBUTES are viable options.  A few values are set programmatically.
-      - rankdir (string, default='TB'): Sets direction of graph layout.  Passed to `pydot.Dot` object.  Options are 'TB' (top to bottom), 'BT' (bottom to top), 'LR' (left to right), 'RL' (right to left).
-      - show_column_keys (bool, default=False): If true then add a PK/FK suffix to columns names that are primary and foreign keys.
-      - restrict_tables (None or list of strings): Restrict the graph to only consider tables whose name are defined `restrict_tables`.
-      - show_schema_name (bool, default=False): If true, then prepend '<schema name>.' to the table name resulting in '<schema name>.<table name>'.
-      - format_schema_name (dict, default=None): If provided, allowed keys include: 'color' (hex color code incl #), 'fontsize' as a float, and 'bold' and 'italics' as bools.
-      - format_table_name (dict, default=None): If provided, allowed keys include: 'color' (hex color code incl #), 'fontsize' as a float, and 'bold' and 'italics' as bools.
+      - metadata (sqlalchemy.MetaData, default=None): SqlAlchemy `MetaData` with reference to related tables.  If none
+        is provided, uses metadata from first entry of `tables` argument.
+      - concentrate (bool, default=True): Specifies if multiedges should be merged into a single edge & partially
+        parallel edges to share overlapping path.  Passed to `pydot.Dot` object.
+      - relation_options (dict, default: None): kwargs passed to pydot.Edge init.  Most attributes in
+        pydot.EDGE_ATTRIBUTES are viable options.  A few values are set programmatically.
+      - rankdir (string, default='TB'): Sets direction of graph layout.  Passed to `pydot.Dot` object.  Options are
+        'TB' (top to bottom), 'BT' (bottom to top), 'LR' (left to right), 'RL' (right to left).
+      - show_column_keys (bool, default=False): If true then add a PK/FK suffix to columns names that are primary and
+        foreign keys.
+      - restrict_tables (None or list of strings): Restrict the graph to only consider tables whose name are defined
+        `restrict_tables`.
+      - show_schema_name (bool, default=False): If true, then prepend '<schema name>.' to the table name resulting in
+        '<schema name>.<table name>'.
+      - format_schema_name (dict, default=None): If provided, allowed keys include: 'color' (hex color code incl #),
+        'fontsize' as a float, and 'bold' and 'italics' as bools.
+      - format_table_name (dict, default=None): If provided, allowed keys include: 'color' (hex color code incl #),
+        'fontsize' as a float, and 'bold' and 'italics' as bools.
     """
 
     relation_kwargs = {
@@ -226,7 +241,11 @@ def create_schema_graph(tables=None, metadata=None, show_indexes=True, show_data
 
         graph.add_node(pydot.Node(str(table.name),
             shape="plaintext",
-            label=_render_table_html(table, metadata, show_indexes, show_datatypes, show_column_keys, show_schema_name, format_schema_name, format_table_name),
+            label=_render_table_html(
+                table, metadata,
+                show_indexes, show_datatypes, show_column_keys, show_schema_name,
+                format_schema_name, format_table_name
+            ),
             fontname=font, fontsize="7.0"
         ))
 

--- a/tests/test_schema_graph.py
+++ b/tests/test_schema_graph.py
@@ -3,7 +3,7 @@ from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import MetaData
 from sqlalchemy import Table
-from utils import parse_graph
+from .utils import parse_graph
 import pydot
 import pytest
 import sqlalchemy_schemadisplay as sasd
@@ -99,3 +99,58 @@ def test_table_filtering(metadata):
     assert result.keys() == ['1']
     assert result['1']['nodes'].keys() == ['bar']
     assert '- foo_id : INTEGER' in result['1']['nodes']['bar']
+
+def test_table_rendering_without_schema(metadata):
+    foo = Table(
+        'foo', metadata,
+        Column('id', types.Integer, primary_key=True))
+    bar = Table(
+        'bar', metadata,
+        Column('foo_id', types.Integer, ForeignKey(foo.c.id)))
+
+    try:
+        sasd.create_schema_graph(metadata=metadata).create_png()
+    except Exception as ex:
+        assert False, f"An exception of type {ex.__class__.__name__} was produced when attempting to render a png of the graph"
+
+def test_table_rendering_with_schema(metadata):
+    foo = Table(
+        'foo', metadata,
+        Column('id', types.Integer, primary_key=True),
+        schema='sch_foo'
+    )
+    bar = Table(
+        'bar', metadata,
+        Column('foo_id', types.Integer, ForeignKey(foo.c.id)),
+        schema='sch_bar'
+    )
+
+    try:
+        sasd.create_schema_graph(
+            metadata=metadata,
+            show_schema_name=True,
+        ).create_png()
+    except Exception as ex:
+        assert False, f"An exception of type {ex.__class__.__name__} was produced when attempting to render a png of the graph"
+
+def test_table_rendering_with_schema_and_formatting(metadata):
+    foo = Table(
+        'foo', metadata,
+        Column('id', types.Integer, primary_key=True),
+        schema='sch_foo'
+    )
+    bar = Table(
+        'bar', metadata,
+        Column('foo_id', types.Integer, ForeignKey(foo.c.id)),
+        schema='sch_bar'
+    )
+
+    try:
+        sasd.create_schema_graph(
+            metadata=metadata,
+            show_schema_name=True,
+            format_schema_name={'fontsize':8.0, 'color': '#888888'},
+            format_table_name={'bold':True, 'fontsize': 10.0},
+        ).create_png()
+    except Exception as ex:
+        assert False, f"An exception of type {ex.__class__.__name__} was produced when attempting to render a png of the graph"

--- a/tests/test_schema_graph.py
+++ b/tests/test_schema_graph.py
@@ -3,7 +3,7 @@ from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import MetaData
 from sqlalchemy import Table
-from .utils import parse_graph
+from utils import parse_graph
 import pydot
 import pytest
 import sqlalchemy_schemadisplay as sasd

--- a/tests/test_uml_graph.py
+++ b/tests/test_uml_graph.py
@@ -5,7 +5,7 @@ from sqlalchemy import MetaData
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import class_mapper
 from sqlalchemy.orm import relationship
-from .utils import parse_graph
+from utils import parse_graph
 import pytest
 import sqlalchemy_schemadisplay as sasd
 

--- a/tests/test_uml_graph.py
+++ b/tests/test_uml_graph.py
@@ -5,7 +5,7 @@ from sqlalchemy import MetaData
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import class_mapper
 from sqlalchemy.orm import relationship
-from utils import parse_graph
+from .utils import parse_graph
 import pytest
 import sqlalchemy_schemadisplay as sasd
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,7 @@
 try:
     from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
+except (ImportError, ModuleNotFoundError):
+    from io import StringIO
 
 
 def parse_graph(graph):


### PR DESCRIPTION
Proposed changes: Add option to show schema name in table header.  Also add formatting options for both schema name and table name.

I'm working on a concept to enable displaying the schema name (addresses #24).  Is this something you're interested in merging?  Would you prefer I take a different approach?

Here's some sample code to illustrate using the changes:

```python
from sqlalchemy import Column, ForeignKeyMetaData
from sqlalchemy.orm import declarative_base
from sqlalchemy import types as t
from sqlalchemy_schemadisplay import create_schema_graph
from IPython.display import Image

md = MetaData(schema="test_schema")
dec_bs = declarative_base(metadata=md)


class TabA(dec_bs):
    __tablename__ = 'tab_a'
    id = Column(t.Integer, primary_key=True)
    
class TabB(dec_bs):
    __tablename__ = 'tab_b'
    id = Column(t.Integer, primary_key=True)
    fk_tab_a_id = Column(t.Integer, ForeignKey(TabA.id), nullable=False)


graph = create_schema_graph(
    metadata=md,
    show_datatypes=False, # The image would get nasty big if we'd show the datatypes
    show_indexes=False,
    concentrate=True ,
    show_column_keys=True,
    show_schema_name=True,
    format_schema_name={'fontsize':8.0},
    format_table_name={'bold':True, 'fontsize': 10.0}
)

Image(data=graph.create_png())
```
![demo](https://user-images.githubusercontent.com/6985440/146183991-fadecac4-81ce-499b-aee8-b5d92ad1ccc3.png)

If this seems like a good direction, I'm planning to write some tests for it, too.  I'd also be happy to add other related changes as requested.

