### PR TITLE
Run tests with GitHub Actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,32 @@
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["2.7", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install tox flake8
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with tox
+      run: |
+        tox

--- a/tests/test_schema_graph.py
+++ b/tests/test_schema_graph.py
@@ -111,7 +111,7 @@ def test_table_rendering_without_schema(metadata):
     try:
         sasd.create_schema_graph(metadata=metadata).create_png()
     except Exception as ex:
-        assert False, f"An exception of type {ex.__class__.__name__} was produced when attempting to render a png of the graph"
+        assert False, "An exception of type {} was produced when attempting to render a png of the graph".format(ex.__class__.__name__)
 
 def test_table_rendering_with_schema(metadata):
     foo = Table(
@@ -131,7 +131,7 @@ def test_table_rendering_with_schema(metadata):
             show_schema_name=True,
         ).create_png()
     except Exception as ex:
-        assert False, f"An exception of type {ex.__class__.__name__} was produced when attempting to render a png of the graph"
+        assert False, "An exception of type {} was produced when attempting to render a png of the graph".format(ex.__class__.__name__)
 
 def test_table_rendering_with_schema_and_formatting(metadata):
     foo = Table(
@@ -153,4 +153,4 @@ def test_table_rendering_with_schema_and_formatting(metadata):
             format_table_name={'bold':True, 'fontsize': 10.0},
         ).create_png()
     except Exception as ex:
-        assert False, f"An exception of type {ex.__class__.__name__} was produced when attempting to render a png of the graph"
+        assert False, "An exception of type {} was produced when attempting to render a png of the graph".format(ex.__class__.__name__)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,6 @@
 try:
     from cStringIO import StringIO
-except (ImportError, ModuleNotFoundError):
+except ImportError:
     from io import StringIO
 
 


### PR DESCRIPTION
This needs more fixes for `tox` which fails to find `pydot`. And also needs `tox.ini` to include Python 3 environment. And maybe (but unlikely) to upload html coverage report to GitHub pages.

I am not too familiar with `tox` to fix `pydot` dependency right now. It seems like `tox` should install `pydot`.