### PR TITLE
Flexible Graph configurations

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
         run: sudo apt-get -y install graphviz
       - name: Cache python dependencies
         id: cache-pip
-        uses: actions/cache@v4.0.5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}
@@ -50,7 +50,7 @@ jobs:
     - uses: actions/checkout@v3.3.0
     - name: Cache python dependencies
       id: cache-pip
-      uses: actions/cache@v4.0.5
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
         run: sudo apt-get -y install graphviz
       - name: Cache python dependencies
         id: cache-pip
-        uses: actions/cache@v3.2.4
+        uses: actions/cache@v4.0.5
         with:
           path: ~/.cache/pip
           key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}
@@ -50,7 +50,7 @@ jobs:
     - uses: actions/checkout@v3.3.0
     - name: Cache python dependencies
       id: cache-pip
-      uses: actions/cache@v3.2.4
+      uses: actions/cache@v4.0.5
       with:
         path: ~/.cache/pip
         key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         run: sudo apt-get -y install graphviz
       - name: Cache python dependencies
         id: cache-pip
-        uses: actions/cache@v3.2.4
+        uses: actions/cache@v4.0.5
         with:
           path: ~/.cache/pip
           key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}
@@ -45,7 +45,7 @@ jobs:
     - uses: actions/checkout@v3.3.0
     - name: Cache python dependencies
       id: cache-pip
-      uses: actions/cache@v3.2.4
+      uses: actions/cache@v4.0.5
       with:
         path: ~/.cache/pip
         key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         run: sudo apt-get -y install graphviz
       - name: Cache python dependencies
         id: cache-pip
-        uses: actions/cache@v4.0.5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}
@@ -45,7 +45,7 @@ jobs:
     - uses: actions/checkout@v3.3.0
     - name: Cache python dependencies
       id: cache-pip
-      uses: actions/cache@v4.0.5
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}

--- a/README.rst
+++ b/README.rst
@@ -65,11 +65,6 @@ And an UML class diagram from a model:
 Changelog
 =========
 
-3.0 - 2025-09-17
-----------------
-
-- Flexible pydot.Dot configurations [ana-barbosa]
-
 2.0 - 2024-02-15
 ----------------
 

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,10 @@ This is an example of database entity diagram generation:
        metadata=MetaData('postgres://user:pwd@host/database'),
        show_datatypes=False, # The image would get nasty big if we'd show the datatypes
        show_indexes=False, # ditto for indexes
-       rankdir='LR', # From left to right (instead of top to bottom)
-       concentrate=False # Don't try to join the relation lines together
+       format_graph={ # Customize your `pydot.Dot` object
+          "rankdir": 'LR', # From left to right (instead of top to bottom)
+          "concentrate": False, # Don't try to join the relation lines together
+       },
     )
     graph.write_png('dbschema.png') # write out the file
 
@@ -62,6 +64,11 @@ And an UML class diagram from a model:
 
 Changelog
 =========
+
+3.0 - 2025-09-17
+----------------
+
+- Flexible pydot.Dot configurations [ana-barbosa]
 
 2.0 - 2024-02-15
 ----------------

--- a/sqlalchemy_schemadisplay/__init__.py
+++ b/sqlalchemy_schemadisplay/__init__.py
@@ -3,7 +3,7 @@ from .db_diagram import create_schema_graph
 from .model_diagram import create_uml_graph
 from .utils import show_schema_graph, show_uml_graph
 
-__version__ = "2.0"
+__version__ = "3.0"
 
 __all__ = (
     "create_schema_graph",

--- a/sqlalchemy_schemadisplay/__init__.py
+++ b/sqlalchemy_schemadisplay/__init__.py
@@ -3,7 +3,7 @@ from .db_diagram import create_schema_graph
 from .model_diagram import create_uml_graph
 from .utils import show_schema_graph, show_uml_graph
 
-__version__ = "3.0"
+__version__ = "2.0"
 
 __all__ = (
     "create_schema_graph",

--- a/tests/test_schema_graph.py
+++ b/tests/test_schema_graph.py
@@ -35,6 +35,33 @@ def test_no_args(engine):
     assert e.value.args[0] == "You need to specify at least tables or metadata"
 
 
+def test_default_graph_args(metadata, engine):
+    graph = sqlalchemy_schemadisplay.create_schema_graph(engine=engine,
+                                                         metadata=metadata)
+    assert graph.get_attributes() == {
+        "prog": "dot",
+        "mode": "ipsep",
+        "overlap": "ipsep",
+        "sep": "0.01",
+        "concentrate": "True",
+        "rankdir": "TB",
+    }
+
+def test_custom_graph_args(metadata, engine):
+    graph = sqlalchemy_schemadisplay.create_schema_graph(engine=engine,
+                                                         metadata=metadata,
+                                                         format_graph={"sep": "0.5", "rankdir":"LR", "dpi": 300})
+    assert graph.get_attributes() == {
+        "prog": "dot",
+        "mode": "ipsep",
+        "overlap": "ipsep",
+        "sep": "0.5",
+        "concentrate": "True",
+        "rankdir": "LR",
+        "dpi": 300,
+    }
+
+
 def test_empty_db(metadata, engine):
     graph = sqlalchemy_schemadisplay.create_schema_graph(engine=engine,
                                                          metadata=metadata)


### PR DESCRIPTION
Motivation:
- The graph resolution generated in my project is too low, making it almost impossible to read (see details below)
- Right now I can't customize the `dpi` attribute as a parameter
- Customizing `dpi` after calling `create_schema_graph` is cumbersome: `graph.obj_dict["attributes"]["dpi"] = 300`

Proposed changes:
- Keep the original set of configs, but aggregated under the new `format_graph` parameter
- Allow users to customize all graph configs exposed by pydot

Image creation examples:
Current implementation without dpi adjustment:
```
graph = create_schema_graph(
    engine=engine,
    metadata=metadata,
    show_datatypes=False,
    show_indexes=False,
    rankdir='LR',
    concentrate=False,
)
graph.write_jpeg('./dbschema.jpeg')
```
![dbschema_before](https://github.com/user-attachments/assets/8e6cf29e-4e13-4d1c-a713-abc947e47edc)

Proposed implementation:
```
graph = create_schema_graph(
    engine=engine,
    metadata=metadata,
    show_datatypes=False,
    show_indexes=False,
    format_graph={"rankdir":"LR", "concentrate": False, "dpi": 300},
)
graph.write_jpeg('./dbschema.jpeg')
```
![dbschema_after](https://github.com/user-attachments/assets/cf67e485-e86c-4e0b-9496-0c21b526d164)


